### PR TITLE
Pre-compress JS and CSS with gzip in release build

### DIFF
--- a/OpenRobertaServer/.classpath
+++ b/OpenRobertaServer/.classpath
@@ -35,5 +35,10 @@
 	<classpathentry combineaccessrules="false" kind="src" path="/RobotEV3"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/RobotNXT"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/RobotSIM"/>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="staticResources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/OpenRobertaServer/.settings/org.eclipse.core.resources.prefs
+++ b/OpenRobertaServer/.settings/org.eclipse.core.resources.prefs
@@ -5,3 +5,4 @@ encoding//src/main/resources=UTF-8
 encoding//src/test/java=UTF-8
 encoding//src/test/resources=UTF-8
 encoding/<project>=UTF-8
+encoding/staticResources=UTF-8

--- a/OpenRobertaServer/pom.xml
+++ b/OpenRobertaServer/pom.xml
@@ -232,14 +232,110 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>1.4.1</version>
+				<executions>
+					<execution>
+						<id>enforce-debug-or-release-profile-is-active</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireActiveProfile>
+									<profiles>debug,release</profiles>
+									<all>false</all>
+								</requireActiveProfile>
+							</rules>
+							<fail>true</fail>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 		<resources>
 			<resource>
 				<directory>src/main/resources</directory>
 				<filtering>true</filtering>
 			</resource>
+			<resource>
+				<directory>staticResources</directory>
+				<targetPath>staticResources</targetPath>
+			</resource>
 		</resources>
 	</build>
+	<profiles>
+		<profile>
+			<id>debug</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
+			<build>
+				<plugins>
+					<!-- Clean out compressed files that may have been added by a release
+							 build. -->
+					<plugin>
+						<artifactId>maven-clean-plugin</artifactId>
+						<version>3.0.0</version>
+						<executions>
+							<execution>
+								<id>remove-stale-generated-files</id>
+								<phase>initialize</phase>
+								<goals>
+									<goal>clean</goal>
+								</goals>
+								<configuration>
+									<filesets>
+										<fileset>
+											<directory>${project.build.directory}</directory>
+											<includes>
+												<include>**/*.gz</include>
+											</includes>
+											<followSymlinks>false</followSymlinks>
+										</fileset>
+									</filesets>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>release</id>
+			<build>
+				<plugins>
+					<!-- Compress javascript and css files with gzip. -->
+					<plugin>
+						<groupId>net.alchim31.maven</groupId>
+						<artifactId>yuicompressor-maven-plugin</artifactId>
+						<version>1.5.1</version>
+						<executions>
+							<execution>
+								<goals>
+									<goal>compress</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<nosuffix>true</nosuffix>
+							<!--
+								Disable javascript compression - just use this plugin for gzip.
+								If we want to use javascript compression we should execute this
+								plugin twice, so we can exclude already-compressed files from
+								the JS-compression but not from gzip-compression.
+							-->
+							<nocompress>true</nocompress>
+							<force>true</force>
+							<gzip>true</gzip>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 	<!-- mvn site creates html test reports and code documentation -->
 	<reporting>
 		<plugins>

--- a/ora.sh
+++ b/ora.sh
@@ -149,8 +149,7 @@ function _exportApplication {
   else
     echo "no database setup"
   fi
-  echo "copying generic resources"
-  cp -r OpenRobertaServer/staticResources "$exportpath"
+  echo "copying OpenRobertaServer JARs"
   mkdir "${exportpath}/resources"
   cp OpenRobertaServer/target/resources/*.jar "$exportpath/resources"
 


### PR DESCRIPTION
Also builds static resources into the OpenRobertaServer JAR rather than
using a separate directory.

To use the release build, pass -Prelease to mvn.

This reduces the page size from about 2.3 MiB to about 800 KiB. This
should improve #56.