### PR TITLE
Support URLs that preselect robot type

### DIFF
--- a/OpenRobertaParent/OpenRobertaServer/staticResources/js/app/roberta/controller/menu.controller.js
+++ b/OpenRobertaParent/OpenRobertaServer/staticResources/js/app/roberta/controller/menu.controller.js
@@ -35,6 +35,9 @@ define([ 'exports', 'log', 'util', 'message', 'comm', 'robot.controller', 'socke
         } else if (target[0] === "#gallery") {
             GUISTATE_C.setStartWithoutPopup();
             $('#tabGalleryList').click();
+        } else if (target[0] === "#loadSystem" && target.length >= 2) {
+            GUISTATE_C.setStartWithoutPopup();
+            ROBOT_C.switchRobot(target[1], true);
         }
         var uri = window.location.toString();
         if (uri.indexOf("#") > 0) {


### PR DESCRIPTION
As advised by @bjost2s in #924, `/#loadSystem&&<robot type>` (e.g. `/#loadSystem&&ev3dev` or  `/#loadSystem&&calliope2017`) skip the robot selection screen and pre-select the specified robot type.

Fixes #924.