### PR TITLE
addressing #928 by moving trashcan to toolbox

### DIFF
--- a/OpenRobertaParent/OpenRobertaServer/staticResources/js/app/roberta/controller/program.controller.js
+++ b/OpenRobertaParent/OpenRobertaServer/staticResources/js/app/roberta/controller/program.controller.js
@@ -23,7 +23,7 @@ define([ 'exports', 'comm', 'message', 'log', 'util', 'guiState.controller', 'pr
         blocklyWorkspace = Blockly.inject(document.getElementById('blocklyDiv'), {
             path : '/blockly/',
             toolbox : toolbox,
-            trashcan : true,
+            trashcan : false,
             scrollbars : true,
             media : '../blockly/media/',
             zoom : {
@@ -49,6 +49,7 @@ define([ 'exports', 'comm', 'message', 'log', 'util', 'guiState.controller', 'pr
         GUISTATE_C.checkSim();
         var toolbox = $('#blockly .blocklyToolboxDiv');
         toolbox.prepend('<ul class="nav nav-tabs levelTabs"><li class="active"><a class="typcn typcn-media-stop-outline" href="#beginner" data-toggle="tab">1</a></li><li class=""><a href="#expert" class="typcn typcn-star-outline" data-toggle="tab">2</a></li></ul>');
+        toolbox.append('<div class="typcn typcn-trash" style="font-size: xx-large; position:absolute; bottom: 0px; left: 12px; width: 48px; height: 48px;"></div>')
     }
 
     function initEvents() {


### PR DESCRIPTION
To improve usability of the trashcan I moved it to the toolbox. As blockly deletes every block you drop on the toolbox automatically, only an icon to make this feature discoverable is needed.

The default blockly trashcan cannot easily be expanded and the 4px border on the right should stay.

This solution has two advantages:
1. The drop area is huge now (whole left side of the screen)
2. You "put blocks back where you found them" is an easier mental model to grasp than looking at the lower right border (where action buttons are which have nothing to do with manipulating blocks).