### PR TITLE
Use native links where possible

### DIFF
--- a/OpenRobertaParent/OpenRobertaServer/staticResources/css/roberta.css
+++ b/OpenRobertaParent/OpenRobertaServer/staticResources/css/roberta.css
@@ -1159,6 +1159,10 @@ table [data-toggle="collapse"].collapsed:after {
     position: relative;
     margin-top: 0;
 }
+.noLinkStyle, .noLinkStyle:hover {
+    text-decoration: none;
+    color: inherit;
+}
 .robot-label {
     display: block;
     white-space: nowrap;

--- a/OpenRobertaParent/OpenRobertaServer/staticResources/index.html
+++ b/OpenRobertaParent/OpenRobertaServer/staticResources/index.html
@@ -932,11 +932,11 @@ limitations under the License.
                         <div class="col-md-3">
                             <!-- <h4 lkey="Blockly.Msg.POPUP_STARTUP_HELP">Do you need help?</h4> -->
                             <div style="text-align: center">
-                                <div id="goToWiki" class="robot-container startupImages" data-dismiss="modal"
+                                <a href="https://jira.iais.fraunhofer.de/wiki/display/ORInfo" target="_blank" id="goToWiki" class="robot-container startupImages noLinkStyle" data-dismiss="modal"
                                     style="background-image: url(/css/img/wiki.png); background-size: contain; background-repeat: no-repeat">
                                     <br>
                                     <span class="robot-label">Open Roberta<br>Wiki</span>
-                                </div>
+                                </a>
                             </div>
                         </div>
                     </div>

--- a/OpenRobertaParent/OpenRobertaServer/staticResources/index.html
+++ b/OpenRobertaParent/OpenRobertaServer/staticResources/index.html
@@ -147,10 +147,10 @@ limitations under the License.
                             lkey="Blockly.Msg.MENU_HELP"></span>
                     </a>
                         <ul class="dropdown-menu">
-                            <li><a href="#" id="menuGeneral" class="menuGeneral typcn typcn-lightbulb" lkey="Blockly.Msg.MENU_GENERAL">Allgemeine Hilfe</a></li>
-                            <li><a href="#" id="menuFaq" class="menuFAQ typcn typcn-lightbulb" lkey="Blockly.Msg.MENU_FAQ">FAQ</a></li>
+                            <li><a href="https://jira.iais.fraunhofer.de/wiki/display/ORInfo" target="_blank" id="menuGeneral" class="menuGeneral typcn typcn-lightbulb" lkey="Blockly.Msg.MENU_GENERAL">Allgemeine Hilfe</a></li>
+                            <li><a href="https://jira.iais.fraunhofer.de/wiki/display/ORInfo/FAQ" target="_blank" id="menuFaq" class="menuFAQ typcn typcn-lightbulb" lkey="Blockly.Msg.MENU_FAQ">FAQ</a></li>
                             <li><a href="#" id="menuAbout" class="typcn typcn-info-large" lkey="Blockly.Msg.MENU_ABOUT">Über das Open Roberta Lab</a></li>
-                            <li><a href="#" id="menuAboutProject" class="menuAboutProject typcn typcn-info-large" lkey="Blockly.Msg.MENU_ABOUT_PROJECT">Über
+                            <li><a href="https://www.roberta-home.de/index.php?id=135" target="_blank" id="menuAboutProject" class="menuAboutProject typcn typcn-info-large" lkey="Blockly.Msg.MENU_ABOUT_PROJECT">Über
                                     das Open Roberta Projekt</a></li>
                             <li><a href="#" id="menuShowStart" class="typcn typcn-refresh" lkey="Blockly.Msg.MENU_SHOW_AGAIN">Starthinweis anzeigen</a></li>
                             <li><a href="#" id="menuLogging" class="typcn typcn-spanner" lkey="Blockly.Msg.MENU_LOGGING">Logging</a></li>

--- a/OpenRobertaParent/OpenRobertaServer/staticResources/index.html
+++ b/OpenRobertaParent/OpenRobertaServer/staticResources/index.html
@@ -251,7 +251,7 @@ limitations under the License.
         </div>
         <!-- Roberta-Logo -->
         <div class="logo">
-            <img href="#" id="img-nepo" class="img-nepo" src="/css/svg/NEPO_Logo_RGB.svg" />
+            <img href="#" id="img-nepo" class="img-nepo" src="/css/svg/NEPO_Logo_RGB.svg" alt="NEPO"/>
         </div>
         <!-- Toasts -->
         <div class="panel-body" id="toastContainer">

--- a/OpenRobertaParent/OpenRobertaServer/staticResources/js/app/roberta/controller/menu.controller.js
+++ b/OpenRobertaParent/OpenRobertaServer/staticResources/js/app/roberta/controller/menu.controller.js
@@ -115,10 +115,6 @@ define([ 'exports', 'log', 'util', 'message', 'comm', 'robot.controller', 'socke
             }
         }
 
-        var giveValue = function(key) {
-            return groupsDict[key];
-        }
-
         var addInfoLink = function(clone, robotName) {
             if (GUISTATE_C.getRobotInfo(robotName) != 'Info not found') {
                 clone.find('a').attr('onclick', 'window.open("' + GUISTATE_C.getRobotInfo(robotName) + '");return false;');

--- a/OpenRobertaParent/OpenRobertaServer/staticResources/js/app/roberta/controller/menu.controller.js
+++ b/OpenRobertaParent/OpenRobertaServer/staticResources/js/app/roberta/controller/menu.controller.js
@@ -117,7 +117,7 @@ define([ 'exports', 'log', 'util', 'message', 'comm', 'robot.controller', 'socke
 
         var addInfoLink = function(clone, robotName) {
             if (GUISTATE_C.getRobotInfo(robotName) != 'Info not found') {
-                clone.find('a').attr('onclick', 'window.open("' + GUISTATE_C.getRobotInfo(robotName) + '");return false;');
+                clone.find('a').attr('href', GUISTATE_C.getRobotInfo(robotName));
             } else {
                 clone.find('a').remove();
             }
@@ -519,6 +519,9 @@ define([ 'exports', 'log', 'util', 'message', 'comm', 'robot.controller', 'socke
             mousey = event.clientY;
         });
         $('.popup-robot').onWrap('click', function(event) {
+            if (event.target.className.indexOf("info") >= 0) {  // Info link has href attribute; do nothing.
+                return;
+            }
             if (Math.abs(event.clientX - mousex) >= 3 || Math.abs(event.clientY - mousey) >= 3) {
                 return;
             }
@@ -526,39 +529,35 @@ define([ 'exports', 'log', 'util', 'message', 'comm', 'robot.controller', 'socke
             $('#startPopupBack').trigger('click');
             var choosenRobotType = event.target.dataset.type || event.currentTarget.dataset.type;
             var choosenRobotGroup = event.target.dataset.group || event.currentTarget.dataset.group;
-            if (event.target.className.indexOf("info") >= 0) {
-                var win = window.open(GUISTATE_C.getRobots()[choosenRobotType].info, '_blank');
-            } else {
-                if (choosenRobotType) {
-                    if (choosenRobotGroup) {
-                        $('#popup-robot-main').addClass('hidden');
-                        $('.popup-robot.' + choosenRobotType).removeClass('hidden');
-                        $('.popup-robot.' + choosenRobotType).addClass('robotSpecial');
-                        $('#startPopupBack').removeClass('hidden');
-                        return;
-                    } else {
-                        ROBOT_C.switchRobot(choosenRobotType, true);
-                    }
-                }
-
-                var cookieName = "OpenRoberta_" + GUISTATE_C.getServerVersion();
-
-                if ($('#checkbox_id').is(':checked')) {
-
-                    var cookieSettings = {
-                        expires : 99,
-                        secure : GUISTATE_C.isPublicServerVersion(),
-                        domain : ''
-                    };
-
-                    CookieDisclaimer.saveCookie(cookieName, choosenRobotType, cookieSettings);
-
+            if (choosenRobotType) {
+                if (choosenRobotGroup) {
+                    $('#popup-robot-main').addClass('hidden');
+                    $('.popup-robot.' + choosenRobotType).removeClass('hidden');
+                    $('.popup-robot.' + choosenRobotType).addClass('robotSpecial');
+                    $('#startPopupBack').removeClass('hidden');
+                    return;
                 } else {
-                    $.removeCookie(cookieName);
+                    ROBOT_C.switchRobot(choosenRobotType, true);
                 }
-
-                $('#show-startup-message').modal('hide');
             }
+
+            var cookieName = "OpenRoberta_" + GUISTATE_C.getServerVersion();
+
+            if ($('#checkbox_id').is(':checked')) {
+
+                var cookieSettings = {
+                    expires : 99,
+                    secure : GUISTATE_C.isPublicServerVersion(),
+                    domain : ''
+                };
+
+                CookieDisclaimer.saveCookie(cookieName, choosenRobotType, cookieSettings);
+
+            } else {
+                $.removeCookie(cookieName);
+            }
+
+            $('#show-startup-message').modal('hide');
         }, 'robot choosen in start popup');
 
         $('#moreReleases').onWrap('click', function(event) {

--- a/OpenRobertaParent/OpenRobertaServer/staticResources/js/app/roberta/controller/menu.controller.js
+++ b/OpenRobertaParent/OpenRobertaServer/staticResources/js/app/roberta/controller/menu.controller.js
@@ -463,20 +463,6 @@ define([ 'exports', 'log', 'util', 'message', 'comm', 'robot.controller', 'socke
             $("#show-startup-message").modal("show");
         }, 'logo was clicked');
 
-        $('.menuGeneral').onWrap('click', function(event) {
-            window.open("https://jira.iais.fraunhofer.de/wiki/display/ORInfo");
-        }, 'head navigation menu item clicked');
-        $('.menuFaq').onWrap('click', function(event) {
-            window.open("https://jira.iais.fraunhofer.de/wiki/display/ORInfo/FAQ");
-        }, 'head navigation menu item clicked');
-        $('.menuAboutProject').onWrap('click', function(event) {
-            if (GUISTATE_C.getLanguage() == 'de') {
-                window.open("https://www.roberta-home.de/index.php?id=135");
-            } else {
-                window.open("https://www.roberta-home.de/index.php?id=135&L=1");
-            }
-        }, 'head navigation menu item clicked');
-
         $('.simScene').onWrap('click', function(event) {
             SIM.setBackground(-1, SIM.setBackground);
             var scene = $("#simButtonsCollapse").collapse('hide');

--- a/OpenRobertaParent/OpenRobertaServer/staticResources/js/app/roberta/controller/menu.controller.js
+++ b/OpenRobertaParent/OpenRobertaServer/staticResources/js/app/roberta/controller/menu.controller.js
@@ -579,14 +579,6 @@ define([ 'exports', 'log', 'util', 'message', 'comm', 'robot.controller', 'socke
             TOUR_C.start('welcome');
         }, 'take a tour clicked');
 
-        $('#goToWiki').onWrap('click', function(event) {
-            event.preventDefault();
-            window.open('https://jira.iais.fraunhofer.de/wiki/display/ORInfo', '_blank');
-            event.stopPropagation();
-            $("#show-startup-message").modal("show");
-
-        }, 'take a tour clicked');
-
         // init popup events
 
         $('.cancelPopup').onWrap('click', function() {


### PR DESCRIPTION
Use native browser links (<a href="...">) where possible. This is simpler and thus robuster than using window.open() in Javascript (and it's also nice to know where a link points to).