### PR TITLE
Allow to select (and copy) the generated code

### DIFF
--- a/OpenRobertaParent/OpenRobertaServer/staticResources/css/roberta.css
+++ b/OpenRobertaParent/OpenRobertaServer/staticResources/css/roberta.css
@@ -271,9 +271,6 @@ body.blocklyMinimalBody * {
     display: none;
     position: relative;
     z-index: 10;
-    user-select: none;
-    -webkit-user-select: none;
-    -moz-user-select: none;
 }
 #infoDiv.fromRight {
     background-color: #eee;

--- a/OpenRobertaParent/OpenRobertaServer/staticResources/js/helper/util.js
+++ b/OpenRobertaParent/OpenRobertaServer/staticResources/js/helper/util.js
@@ -422,6 +422,9 @@ define([ 'exports', 'message', 'log', 'jquery', 'jquery-validate', 'bootstrap' ]
         var $elements = (opt.handle === "") ? this : this.find(opt.handle);
 
         $elements.css('cursor', opt.cursor).on("mousedown touchstart", function(e) {
+            e.preventDefault();
+            e.stopPropagation();
+        
             var pageX = e.pageX || e.originalEvent.touches[0].pageX;
             var pageY = e.pageY || e.originalEvent.touches[0].pageY;
             if (opt.handle === "") {


### PR DESCRIPTION
This ability was broken in ac3ff2e7031fa67b39d37d29f31e5fe973b329da by using `user-select: none;` CSS.